### PR TITLE
Bruk "pixelated" metode for å skalere pikseltegning

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -89,6 +89,7 @@ textarea {
 
 .pokemon-entry img {
     transition: transform 200ms;
+    image-rendering: pixelated;
 }
 
 .enlarge {


### PR DESCRIPTION
Standard skalering er ofte beregnet på fotografi eller lignende, og gjengir ikke pikselkunst/pikseltegninger(??) med skarpe "piksler". 🤓

Denne endringen bytter til `pixelated`. `crisp-edges` gir potensielt enda skarpere kanter, men kan føre til ujevn størrelse på de endelige "pikslene" (superpiksler?)
|før|etter|
|---|---|
|<img width="211" alt="image" src="https://user-images.githubusercontent.com/17160920/228289205-385a35b8-235b-45ba-8407-90063acd5cee.png">|<img width="213" alt="image" src="https://user-images.githubusercontent.com/17160920/228288274-431831c7-6f69-4624-9d2d-1920c61d12a5.png">|